### PR TITLE
refactor: centralize tag generation

### DIFF
--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -1,0 +1,21 @@
+from django.utils.text import slugify
+from apps.submissions.models import Submission
+
+
+def get_tag_items():
+    """Return ordered tag names, tag items and slug-to-name mapping."""
+    names = []
+    for s in Submission.objects.filter(status='published').only('stack_tags_json'):
+        if s.stack_tags_json:
+            names.extend([t for t in s.stack_tags_json if isinstance(t, str) and t])
+    seen = set()
+    names = [t for t in names if not (t in seen or seen.add(t))]
+    tag_items = []
+    mapping = {}
+    for name in names:
+        slug = slugify(name)
+        if slug in mapping:
+            continue
+        mapping[slug] = name
+        tag_items.append({'slug': slug, 'name': name})
+    return names, tag_items, mapping


### PR DESCRIPTION
## Summary
- add `get_tag_items` utility to build tag names, items, and mapping
- refactor HomeView and TagView to use new helper for tag navigation

## Testing
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_68bd916d64fc83249dacc3b6047aa821