### PR TITLE
Add rel injection only for links missing the attribute

### DIFF
--- a/apps/submissions/markdown.py
+++ b/apps/submissions/markdown.py
@@ -1,5 +1,6 @@
 import markdown as _md
 import bleach
+import re
 
 
 ALLOWED_TAGS = [
@@ -23,10 +24,12 @@ def render_markdown(md_text: str) -> str:
         protocols=ALLOWED_PROTOCOLS,
         strip=True,
     )
-    # Ensure links have rel
-    def _add_rel(m):
-        return m.replace('<a ', '<a rel="nofollow noopener" ', 1) if ' rel=' not in m else m
-    # quick and simple injection for rel attr
-    cleaned = cleaned.replace('<a ', '<a rel="nofollow noopener" ')
+    # Ensure links without a rel attribute get the default
+    cleaned = re.sub(
+        r"<a(?![^>]*\brel=)([^>]*)>",
+        r'<a\1 rel="nofollow noopener">',
+        cleaned,
+        flags=re.IGNORECASE,
+    )
     return cleaned
 

--- a/apps/submissions/tests/test_markdown.py
+++ b/apps/submissions/tests/test_markdown.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+from apps.submissions.markdown import render_markdown
+
+
+def test_adds_rel_when_missing():
+    html = render_markdown("[link](https://example.com)")
+    assert '<a href="https://example.com" rel="nofollow noopener">' in html
+
+
+def test_existing_rel_preserved():
+    html = render_markdown('<a href="https://example.com" rel="me">link</a>')
+    assert 'rel="me"' in html
+    assert 'nofollow' not in html
+


### PR DESCRIPTION
## Summary
- sanitize markdown links with regex to add `rel="nofollow noopener"` only when missing
- remove unused `_add_rel` helper
- add tests covering links with and without existing `rel`

## Testing
- `pytest`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68bd92944bc08324b1dc26202353d1f4