### PR TITLE
chore: remove unused imports from submissions views

### DIFF
--- a/apps/submissions/views.py
+++ b/apps/submissions/views.py
@@ -1,8 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.views.generic import DetailView, FormView
-from django.utils import timezone
-from django.http import Http404
 
 from django.contrib.syndication.views import Feed
 from django.urls import reverse


### PR DESCRIPTION
## Summary
- remove unused timezone and Http404 imports from submissions views

## Testing
- `ruff check apps/submissions/views.py`
- `uv run python manage.py check`
- `uv run python manage.py makemigrations --check --dry-run`
- `uv run python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bd95da996c8324af4886297682208a