### PR TITLE
Add tests for submissions and form validation

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/apps/core/tests/__init__.py
+++ b/apps/core/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/apps/moderation/tests/__init__.py
+++ b/apps/moderation/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/apps/submissions/tests/__init__.py
+++ b/apps/submissions/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/apps/submissions/tests/test_forms.py
+++ b/apps/submissions/tests/test_forms.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from django.test import TestCase
+
+from apps.submissions.forms import SubmissionForm
+
+
+class SubmissionFormTests(TestCase):
+    def _valid_data(self, **overrides):
+        data = {
+            "title": "Test Title",
+            "snapshot": "s" * 280,
+            "idea_md": "idea",
+            "tech_md": "tech",
+            "execution_md": "exec",
+            "failure_md": "fail",
+            "lessons_md": "lessons",
+        }
+        data.update(overrides)
+        return data
+
+    def test_snapshot_length_validation(self):
+        data = self._valid_data(snapshot="a" * 279)
+        form = SubmissionForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("snapshot", form.errors)
+
+    def test_links_parsed_into_json(self):
+        links_text = "http://example.com\n\nhttps://foo.com"
+        data = self._valid_data(links=links_text)
+        form = SubmissionForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["links_json"], [
+            "http://example.com",
+            "https://foo.com",
+        ])

--- a/apps/submissions/tests/test_models.py
+++ b/apps/submissions/tests/test_models.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from django.test import TestCase
+
+from apps.submissions.models import Submission, strip_h1_h2
+
+
+class StripH1H2Tests(TestCase):
+    def test_removes_h1_and_h2_lines(self):
+        md = "# Title\nFirst line\n## Subtitle\nSecond line"
+        result = strip_h1_h2(md)
+        self.assertEqual(result, "First line\nSecond line")
+
+
+class SubmissionSlugTests(TestCase):
+    def _create_submission(self, title="My Title"):
+        return Submission.objects.create(
+            title=title,
+            snapshot="s" * 280,
+            idea_md="idea",
+            tech_md="tech",
+            execution_md="exec",
+            failure_md="fail",
+            lessons_md="lessons",
+        )
+
+    @patch("apps.submissions.models._short_id", return_value="abc123")
+    def test_generates_slug_from_title_and_short_id(self, mock_short_id):
+        sub = self._create_submission()
+        self.assertTrue(sub.slug.startswith("my-title-"))
+        self.assertEqual(sub.slug, "my-title-abc123")
+
+    @patch("apps.submissions.models._short_id", side_effect=["abc123", "abc123", "def456"])
+    def test_slug_uniqueness_with_duplicate_titles(self, mock_short_id):
+        first = self._create_submission(title="Same Title")
+        second = self._create_submission(title="Same Title")
+        self.assertEqual(first.slug, "same-title-abc123")
+        self.assertEqual(second.slug, "same-title-def456")
+        self.assertNotEqual(first.slug, second.slug)


### PR DESCRIPTION
## Summary
- add test packages for each app
- test slug generation and markdown stripping in submissions
- validate snapshot length and link parsing in submission form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bd95dc539c832490cde85ddb0aaf46