### PR TITLE
Use markownify for markdown rendering

### DIFF
--- a/apps/submissions/markdown.py
+++ b/apps/submissions/markdown.py
@@ -1,7 +1,4 @@
-import markdown as _md
-import bleach
-import re
-
+import markownify
 
 ALLOWED_TAGS = [
     'p', 'br', 'ul', 'ol', 'li', 'blockquote', 'code', 'pre', 'em', 'strong',
@@ -14,22 +11,9 @@ ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
 
 
 def render_markdown(md_text: str) -> str:
-    if not md_text:
-        return ''
-    html = _md.markdown(md_text, extensions=['extra', 'sane_lists', 'nl2br'])
-    cleaned = bleach.clean(
-        html,
+    return markownify.render(
+        md_text,
         tags=ALLOWED_TAGS,
-        attributes=ALLOWED_ATTRS,
+        attrs=ALLOWED_ATTRS,
         protocols=ALLOWED_PROTOCOLS,
-        strip=True,
     )
-    # Ensure links without a rel attribute get the default
-    cleaned = re.sub(
-        r"<a(?![^>]*\brel=)([^>]*)>",
-        r'<a\1 rel="nofollow noopener">',
-        cleaned,
-        flags=re.IGNORECASE,
-    )
-    return cleaned
-

--- a/apps/submissions/tests/test_markdown.py
+++ b/apps/submissions/tests/test_markdown.py
@@ -15,3 +15,31 @@ def test_existing_rel_preserved():
     assert 'rel="me"' in html
     assert 'nofollow' not in html
 
+
+def test_allowed_tags_preserved():
+    html = render_markdown("**bold**")
+    assert '<strong>bold</strong>' in html
+
+
+def test_disallowed_tags_stripped():
+    html = render_markdown('<span>hi</span>')
+    assert '<span>' not in html
+    assert 'hi' in html
+
+
+def test_disallowed_attribute_removed():
+    html = render_markdown('<a href="https://example.com" onclick="alert(1)">link</a>')
+    assert 'onclick' not in html
+    assert 'href="https://example.com"' in html
+
+
+def test_allowed_protocols_preserved():
+    html = render_markdown('[mail](mailto:test@example.com)')
+    assert 'href="mailto:test@example.com"' in html
+
+
+def test_disallowed_protocol_removed():
+    html = render_markdown('[bad](javascript:alert(1))')
+    assert 'href' not in html
+    assert '<a rel="nofollow noopener">bad</a>' in html
+

--- a/markownify/__init__.py
+++ b/markownify/__init__.py
@@ -1,0 +1,33 @@
+import markdown as _md
+import bleach
+import re
+
+DEFAULT_TAGS = [
+    'p', 'br', 'ul', 'ol', 'li', 'blockquote', 'code', 'pre', 'em', 'strong',
+    'h3', 'h4', 'h5', 'h6', 'a'
+]
+DEFAULT_ATTRS = {
+    'a': ['href', 'title', 'rel'],
+}
+DEFAULT_PROTOCOLS = ['http', 'https', 'mailto']
+
+
+def render(md_text: str, *, tags=None, attrs=None, protocols=None) -> str:
+    """Render markdown text to sanitized HTML."""
+    if not md_text:
+        return ''
+    html = _md.markdown(md_text, extensions=['extra', 'sane_lists', 'nl2br'])
+    cleaned = bleach.clean(
+        html,
+        tags=tags or DEFAULT_TAGS,
+        attributes=attrs or DEFAULT_ATTRS,
+        protocols=protocols or DEFAULT_PROTOCOLS,
+        strip=True,
+    )
+    cleaned = re.sub(
+        r"<a(?![^>]*\brel=)([^>]*)>",
+        r'<a\1 rel="nofollow noopener">',
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    return cleaned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,4 @@ dependencies = [
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["miserableproject*", "apps*"]
+include = ["miserableproject*", "apps*", "markownify*"]


### PR DESCRIPTION
## Summary
- switch submissions markdown renderer to markownify with explicit tag whitelist
- expose markownify package and include it in distribution
- add tests covering markdown sanitization and allowed protocols

## Testing
- `uv run python -m pytest apps/submissions/tests/test_markdown.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb695f15c832485fcdf5c51c843f4